### PR TITLE
Change for...in loop to for...of during GC

### DIFF
--- a/src/Transaction.js
+++ b/src/Transaction.js
@@ -505,7 +505,7 @@ module.exports = function (Y/* :any */) {
             */
             // ** Now the new implementation starts **
             // reset neworigin of all originOf[*]
-            for (var _i in o.originOf) {
+            for (var _i of o.originOf) {
               var originsIn = yield* this.getOperation(o.originOf[_i])
               if (originsIn != null) {
                 originsIn.origin = neworigin


### PR DESCRIPTION
for...in loop is causing random console error during garbage collection. It breaks the yjs since it is meant for enumeration, not iteration.